### PR TITLE
Fix Ralph Wiggum Loop script errors

### DIFF
--- a/ralph-loop-setup.skill
+++ b/ralph-loop-setup.skill
@@ -98,11 +98,29 @@ usage() {
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        -m) MAX_ITERATIONS="$2"; shift 2 ;;
-        -w) WORKING_DIR="$2"; shift 2 ;;
-        -t) TIMEOUT_SECONDS="$2"; shift 2 ;;
+        -m)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo -e "${RED}Error: -m requires a numeric value${NC}"; exit 1
+            fi
+            if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                echo -e "${RED}Error: -m must be a positive integer${NC}"; exit 1
+            fi
+            MAX_ITERATIONS="$2"; shift 2 ;;
+        -w)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo -e "${RED}Error: -w requires a directory path${NC}"; exit 1
+            fi
+            WORKING_DIR="$2"; shift 2 ;;
+        -t)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo -e "${RED}Error: -t requires a numeric value${NC}"; exit 1
+            fi
+            if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                echo -e "${RED}Error: -t must be a positive integer${NC}"; exit 1
+            fi
+            TIMEOUT_SECONDS="$2"; shift 2 ;;
         -h) usage ;;
-        -*) echo "Unknown option: $1"; exit 1 ;;
+        -*) echo -e "${RED}Error: Unknown option: $1${NC}"; exit 1 ;;
         *) TODO_FILE="$1"; shift ;;
     esac
 done


### PR DESCRIPTION
Add proper validation for -m, -t, and -w command-line arguments in the embedded script template. Without validation, missing or invalid argument values could cause cryptic errors like "integer expression expected" when the flag itself gets assigned instead of the subsequent value.

Validation now:
- Checks if next argument exists and is not another flag
- Validates numeric arguments are positive integers
- Shows clear error messages with colored output