### PR TITLE
Add support for Codex CLI alongside Claude Code

### DIFF
--- a/ralph-loop-setup.skill
+++ b/ralph-loop-setup.skill
@@ -5,7 +5,7 @@ description: Set up automated task implementation system with Ralph Wiggum Loop.
 
 # Ralph Loop Setup Skill
 
-You are helping the user set up the Ralph Wiggum Loop - an automated task implementation system that uses Claude Code to intelligently work through a project todo list.
+You are helping the user set up the Ralph Wiggum Loop - an automated task implementation system that uses an AI coding assistant (Claude Code or Codex) to intelligently work through a project todo list. The script auto-detects which CLI is available at runtime.
 
 **Key Feature**: Rather than strictly following priority order, Claude analyzes the full todo list and uses AI judgment to select the most impactful task based on strategic value, dependencies, likelihood of success, and logical ordering.
 
@@ -64,8 +64,8 @@ Write the following script:
 # Ralph Wiggum Loop - Automated Task Implementation
 # "I'm helping!" - Ralph Wiggum
 #
-# A simple loop that runs Claude Code to work through tasks.
-# Claude AI handles all the intelligence: task selection, implementation,
+# A simple loop that runs an AI coding assistant (claude or codex) to work through tasks.
+# The AI handles all the intelligence: task selection, implementation,
 # logging, and status updates.
 
 set -u
@@ -99,11 +99,39 @@ echo "Working dir: $WORKING_DIR"
 echo "Max iterations: $MAX_ITERATIONS"
 echo ""
 
-# Check dependencies
-if ! command -v claude &> /dev/null; then
-    echo -e "${RED}Error: 'claude' CLI not found${NC}"
+# Detect AI CLI platform (codex or claude)
+detect_ai_cli() {
+    if command -v codex &> /dev/null; then
+        echo "codex"
+    elif command -v claude &> /dev/null; then
+        echo "claude"
+    else
+        echo ""
+    fi
+}
+
+AI_CLI=$(detect_ai_cli)
+
+if [ -z "$AI_CLI" ]; then
+    echo -e "${RED}Error: No AI CLI found. Install 'claude' or 'codex' CLI.${NC}"
     exit 1
 fi
+
+echo "Using AI CLI: $AI_CLI"
+
+# Build the appropriate command based on detected CLI
+run_ai_command() {
+    local prompt="$1"
+    local log_file="$2"
+
+    if [ "$AI_CLI" = "codex" ]; then
+        # Codex uses 'exec' subcommand with --full-auto and '-' for stdin
+        echo "$prompt" | codex exec --full-auto - > "$log_file" 2>&1
+    else
+        # Claude Code uses --dangerously-skip-permissions and --print
+        echo "$prompt" | claude --dangerously-skip-permissions --print > "$log_file" 2>&1
+    fi
+}
 
 if [ ! -f "$TODO_FILE" ]; then
     echo -e "${RED}Error: Todo file not found: $TODO_FILE${NC}"
@@ -174,18 +202,18 @@ while [ $iteration -lt $MAX_ITERATIONS ]; do
         -e "s|PROGRESSFILE_PLACEHOLDER|$PROGRESS_FILE|g" \
         -e "s|WORKINGDIR_PLACEHOLDER|$WORKING_DIR|g")
 
-    # Run Claude in the working directory
+    # Run AI CLI in the working directory
     log_file="${LOG_DIR}/iteration_${iteration}_$(date +%Y%m%d_%H%M%S).log"
 
-    echo "Running Claude..."
+    echo "Running $AI_CLI..."
     echo ""
 
     cd "$WORKING_DIR"
-    if echo "$prompt" | claude --dangerously-skip-permissions --print > "$log_file" 2>&1; then
+    if run_ai_command "$prompt" "$log_file"; then
         echo -e "${GREEN}Iteration $iteration completed${NC}"
     else
         exit_code=$?
-        echo -e "${YELLOW}Claude exited with code $exit_code${NC}"
+        echo -e "${YELLOW}$AI_CLI exited with code $exit_code${NC}"
     fi
 
     echo "Log: $log_file"

--- a/ralph-loop-setup/SKILL.md
+++ b/ralph-loop-setup/SKILL.md
@@ -5,7 +5,7 @@ description: Set up or update automated task implementation system with Ralph Wi
 
 # Ralph Loop Setup Skill
 
-You are helping the user set up or update the 3 files needed to run a Ralph Wiggum Loop - an automated task implementation system that uses Claude Code to intelligently work through a project todo list.
+You are helping the user set up or update the 3 files needed to run a Ralph Wiggum Loop - an automated task implementation system that uses an AI coding assistant (Claude Code or Codex) to intelligently work through a project todo list. The script auto-detects which CLI is available at runtime.
 
 **Key Feature**: Rather than strictly following priority order, Claude analyzes the full todo list and uses AI judgment to select the most impactful task based on strategic value, dependencies, likelihood of success, and logical ordering.
 

--- a/ralph-loop-setup/resources/ralph_wiggum_loop.sh
+++ b/ralph-loop-setup/resources/ralph_wiggum_loop.sh
@@ -3,8 +3,8 @@
 # Ralph Wiggum Loop - Automated Task Implementation
 # "I'm helping!" - Ralph Wiggum
 #
-# A simple loop that runs Claude Code to work through tasks.
-# Claude AI handles all the intelligence: task selection, implementation,
+# A simple loop that runs an AI coding assistant (claude or codex) to work through tasks.
+# The AI handles all the intelligence: task selection, implementation,
 # logging, and status updates.
 
 set -u
@@ -38,11 +38,39 @@ echo "Working dir: $WORKING_DIR"
 echo "Max iterations: $MAX_ITERATIONS"
 echo ""
 
-# Check dependencies
-if ! command -v claude &> /dev/null; then
-    echo -e "${RED}Error: 'claude' CLI not found${NC}"
+# Detect AI CLI platform (codex or claude)
+detect_ai_cli() {
+    if command -v codex &> /dev/null; then
+        echo "codex"
+    elif command -v claude &> /dev/null; then
+        echo "claude"
+    else
+        echo ""
+    fi
+}
+
+AI_CLI=$(detect_ai_cli)
+
+if [ -z "$AI_CLI" ]; then
+    echo -e "${RED}Error: No AI CLI found. Install 'claude' or 'codex' CLI.${NC}"
     exit 1
 fi
+
+echo "Using AI CLI: $AI_CLI"
+
+# Build the appropriate command based on detected CLI
+run_ai_command() {
+    local prompt="$1"
+    local log_file="$2"
+
+    if [ "$AI_CLI" = "codex" ]; then
+        # Codex uses 'exec' subcommand with --full-auto and '-' for stdin
+        echo "$prompt" | codex exec --full-auto - > "$log_file" 2>&1
+    else
+        # Claude Code uses --dangerously-skip-permissions and --print
+        echo "$prompt" | claude --dangerously-skip-permissions --print > "$log_file" 2>&1
+    fi
+}
 
 if [ ! -f "$TODO_FILE" ]; then
     echo -e "${RED}Error: Todo file not found: $TODO_FILE${NC}"
@@ -113,18 +141,18 @@ while [ $iteration -lt $MAX_ITERATIONS ]; do
         -e "s|PROGRESSFILE_PLACEHOLDER|$PROGRESS_FILE|g" \
         -e "s|WORKINGDIR_PLACEHOLDER|$WORKING_DIR|g")
 
-    # Run Claude in the working directory
+    # Run AI CLI in the working directory
     log_file="${LOG_DIR}/iteration_${iteration}_$(date +%Y%m%d_%H%M%S).log"
 
-    echo "Running Claude..."
+    echo "Running $AI_CLI..."
     echo ""
 
     cd "$WORKING_DIR"
-    if echo "$prompt" | claude --dangerously-skip-permissions --print > "$log_file" 2>&1; then
+    if run_ai_command "$prompt" "$log_file"; then
         echo -e "${GREEN}Iteration $iteration completed${NC}"
     else
         exit_code=$?
-        echo -e "${YELLOW}Claude exited with code $exit_code${NC}"
+        echo -e "${YELLOW}$AI_CLI exited with code $exit_code${NC}"
     fi
 
     echo "Log: $log_file"

--- a/ralph_wiggum_loop.sh
+++ b/ralph_wiggum_loop.sh
@@ -3,8 +3,8 @@
 # Ralph Wiggum Loop - Automated Task Implementation
 # "I'm helping!" - Ralph Wiggum
 #
-# A simple loop that runs Claude Code to work through tasks.
-# Claude AI handles all the intelligence: task selection, implementation,
+# A simple loop that runs an AI coding assistant (claude or codex) to work through tasks.
+# The AI handles all the intelligence: task selection, implementation,
 # logging, and status updates.
 
 set -u
@@ -38,11 +38,39 @@ echo "Working dir: $WORKING_DIR"
 echo "Max iterations: $MAX_ITERATIONS"
 echo ""
 
-# Check dependencies
-if ! command -v claude &> /dev/null; then
-    echo -e "${RED}Error: 'claude' CLI not found${NC}"
+# Detect AI CLI platform (codex or claude)
+detect_ai_cli() {
+    if command -v codex &> /dev/null; then
+        echo "codex"
+    elif command -v claude &> /dev/null; then
+        echo "claude"
+    else
+        echo ""
+    fi
+}
+
+AI_CLI=$(detect_ai_cli)
+
+if [ -z "$AI_CLI" ]; then
+    echo -e "${RED}Error: No AI CLI found. Install 'claude' or 'codex' CLI.${NC}"
     exit 1
 fi
+
+echo "Using AI CLI: $AI_CLI"
+
+# Build the appropriate command based on detected CLI
+run_ai_command() {
+    local prompt="$1"
+    local log_file="$2"
+
+    if [ "$AI_CLI" = "codex" ]; then
+        # Codex uses 'exec' subcommand with --full-auto and '-' for stdin
+        echo "$prompt" | codex exec --full-auto - > "$log_file" 2>&1
+    else
+        # Claude Code uses --dangerously-skip-permissions and --print
+        echo "$prompt" | claude --dangerously-skip-permissions --print > "$log_file" 2>&1
+    fi
+}
 
 if [ ! -f "$TODO_FILE" ]; then
     echo -e "${RED}Error: Todo file not found: $TODO_FILE${NC}"
@@ -113,18 +141,18 @@ while [ $iteration -lt $MAX_ITERATIONS ]; do
         -e "s|PROGRESSFILE_PLACEHOLDER|$PROGRESS_FILE|g" \
         -e "s|WORKINGDIR_PLACEHOLDER|$WORKING_DIR|g")
 
-    # Run Claude in the working directory
+    # Run AI CLI in the working directory
     log_file="${LOG_DIR}/iteration_${iteration}_$(date +%Y%m%d_%H%M%S).log"
 
-    echo "Running Claude..."
+    echo "Running $AI_CLI..."
     echo ""
 
     cd "$WORKING_DIR"
-    if echo "$prompt" | claude --dangerously-skip-permissions --print > "$log_file" 2>&1; then
+    if run_ai_command "$prompt" "$log_file"; then
         echo -e "${GREEN}Iteration $iteration completed${NC}"
     else
         exit_code=$?
-        echo -e "${YELLOW}Claude exited with code $exit_code${NC}"
+        echo -e "${YELLOW}$AI_CLI exited with code $exit_code${NC}"
     fi
 
     echo "Log: $log_file"


### PR DESCRIPTION
## Summary
Extended the Ralph Wiggum Loop automation system to support both Claude Code and Codex AI coding assistants, with automatic runtime detection of which CLI is available.

## Key Changes
- **Auto-detection logic**: Added `detect_ai_cli()` function that checks for `codex` first, then falls back to `claude`, enabling seamless switching between platforms
- **Abstracted AI command execution**: Created `run_ai_command()` function that handles platform-specific CLI invocations:
  - Codex: Uses `codex exec --full-auto -` for stdin-based execution
  - Claude: Uses `claude --dangerously-skip-permissions --print` as before
- **Updated documentation**: Modified descriptions in skill files and script comments to reflect support for both AI assistants
- **Improved error messaging**: Changed dependency check to report missing either CLI rather than specifically requiring Claude
- **Consistent variable usage**: Updated all references to use `$AI_CLI` variable for platform-agnostic output messages

## Implementation Details
- Detection prioritizes Codex over Claude (checks Codex first)
- Both CLIs receive the same prompt via stdin and output to the same log file
- No changes to the core task selection or iteration logic
- Backward compatible: existing Claude-only setups continue to work without modification
- Updated in all three locations: main skill file, resource template, and standalone script