### PR TITLE
docs: Add macOS compatibility warning for timeout command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,27 @@
 
 ## Important Reminders
 
+### macOS Compatibility - NO `timeout` Command
+
+**CRITICAL**: The `timeout` command does NOT exist on macOS. Never use it in shell scripts.
+
+**Alternatives:**
+- Use `gtimeout` from coreutils (requires `brew install coreutils`)
+- Use a background process with `sleep` and `kill`
+- Use Perl: `perl -e 'alarm 30; exec @ARGV' "command"`
+
+**Example cross-platform pattern:**
+```bash
+if command -v timeout &>/dev/null; then
+    timeout 30 some_command
+elif command -v gtimeout &>/dev/null; then
+    gtimeout 30 some_command
+else
+    # Fallback without timeout
+    some_command
+fi
+```
+
 ### Keep Skill Files in Sync
 
 **CRITICAL**: Whenever you modify `ralph_wiggum_loop.sh`, you MUST also update ALL skill files to reflect the same changes.


### PR DESCRIPTION
## Summary
Added critical documentation about macOS compatibility issues with the `timeout` command, which is not available on macOS by default.

## Changes
- Added new "macOS Compatibility - NO `timeout` Command" section to CLAUDE.md
- Documented that `timeout` does not exist on macOS and should never be used
- Provided three alternative approaches:
  - Using `gtimeout` from coreutils (via `brew install coreutils`)
  - Using background processes with `sleep` and `kill`
  - Using Perl's `alarm` function
- Included a cross-platform code pattern example that checks for command availability and falls back gracefully

## Details
This documentation serves as a critical reminder for developers working on shell scripts to avoid platform-specific assumptions. The example pattern demonstrates best practices for writing portable shell scripts that work across both Linux (with `timeout`) and macOS (without `timeout`).