### PR TITLE
Add sequential tool call requirement to system prompts

### DIFF
--- a/ralph-loop-setup.skill
+++ b/ralph-loop-setup.skill
@@ -164,6 +164,7 @@ You are an AI assistant working through a project todo list.
 - Update both todolist.json and progress.txt before finishing
 - If a task fails, mark it "failed" with notes explaining why
 - If no eligible tasks remain, just report that and exit
+- **CRITICAL: Make tool calls SEQUENTIALLY, one at a time. Do NOT make parallel tool calls.** This is required for stdin pipe mode compatibility.
 
 ## Files
 

--- a/ralph-loop-setup/resources/ralph_wiggum_loop.sh
+++ b/ralph-loop-setup/resources/ralph_wiggum_loop.sh
@@ -103,6 +103,7 @@ You are an AI assistant working through a project todo list.
 - Update both todolist.json and progress.txt before finishing
 - If a task fails, mark it "failed" with notes explaining why
 - If no eligible tasks remain, just report that and exit
+- **CRITICAL: Make tool calls SEQUENTIALLY, one at a time. Do NOT make parallel tool calls.** This is required for stdin pipe mode compatibility.
 
 ## Files
 

--- a/ralph_wiggum_loop.sh
+++ b/ralph_wiggum_loop.sh
@@ -103,6 +103,7 @@ You are an AI assistant working through a project todo list.
 - Update both todolist.json and progress.txt before finishing
 - If a task fails, mark it "failed" with notes explaining why
 - If no eligible tasks remain, just report that and exit
+- **CRITICAL: Make tool calls SEQUENTIALLY, one at a time. Do NOT make parallel tool calls.** This is required for stdin pipe mode compatibility.
 
 ## Files
 


### PR DESCRIPTION
## Summary
Updated system prompts across multiple files to explicitly require sequential tool calls instead of parallel execution. This change ensures compatibility with stdin pipe mode operations.

## Changes
- Added critical constraint to ralph-loop-setup.skill system prompt
- Added critical constraint to ralph-loop-setup/resources/ralph_wiggum_loop.sh system prompt
- Added critical constraint to ralph_wiggum_loop.sh system prompt

All three files now include the requirement: **"Make tool calls SEQUENTIALLY, one at a time. Do NOT make parallel tool calls."**

## Details
The addition of this constraint is necessary for stdin pipe mode compatibility. When operating in pipe mode, the system cannot handle concurrent tool invocations, so all tool calls must be made sequentially to ensure proper execution and avoid race conditions or input/output conflicts.